### PR TITLE
Support plugins being passed as functions from .js

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ $ markdownlint-cli2 "**/*.md" "#node_modules"
 
 - The format of this file is a [CommonJS module][commonjs-module] that exports
   the object described above for `.markdownlint-cli2.jsonc`.
+- Instead of passing a `String` to identify the module name/path to load for
+  `customRules`, `markdownItPlugins`, and `outputFormatters`, the corresponding
+  `Object` or `Function` can be provided directly.
 - Other details are the same as for `.markdownlint-cli2.jsonc` described above.
 - If a `.markdownlint-cli2.jsonc` or `.markdownlint-cli2.yaml` file is present
   in the same directory, it takes precedence.

--- a/markdownlint-cli2.js
+++ b/markdownlint-cli2.js
@@ -39,9 +39,12 @@ const readConfig = (dir, name, otherwise) => {
 
 // Require a module ID with the specified directory in the path
 const requireResolve = (dir, id) => {
-  const paths = [ dir, ...require.resolve.paths("") ];
-  const resolved = require.resolve(id, { paths });
-  return require(resolved);
+  if (typeof id === "string") {
+    const paths = [ dir, ...require.resolve.paths("") ];
+    const resolved = require.resolve(id, { paths });
+    return require(resolved);
+  }
+  return id;
 };
 
 // Require an array of modules by ID

--- a/test/customRules-pre-imported.stderr
+++ b/test/customRules-pre-imported.stderr
@@ -1,0 +1,6 @@
+viewme.md:3 any-blockquote Rule that reports an error for any blockquote [Blockquote spans 1 line(s).] [Context: "> Tagli"]
+viewme.md:3:10 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
+viewme.md:5 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
+viewme.md:6 MD025/single-title/single-h1 Multiple top level headings in the same document [Context: "# Description"]
+viewme.md:12:1 MD019/no-multiple-space-atx Multiple spaces after hash on atx style heading [Context: "##  Summary"]
+viewme.md:14:14 MD047/single-trailing-newline Files should end with a single newline character

--- a/test/customRules-pre-imported.stdout
+++ b/test/customRules-pre-imported.stdout
@@ -1,0 +1,3 @@
+Finding: **/*.md
+Linting: 1 file(s)
+Summary: 6 error(s)

--- a/test/customRules-pre-imported/.markdownlint-cli2.js
+++ b/test/customRules-pre-imported/.markdownlint-cli2.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+"use strict";
+
+const anyBlockquote = require("./rules/any-blockquote.js");
+
+module.exports = {
+  "customRules": [
+    anyBlockquote,
+  ],
+}

--- a/test/customRules-pre-imported/rules/any-blockquote.js
+++ b/test/customRules-pre-imported/rules/any-blockquote.js
@@ -1,0 +1,26 @@
+// @ts-check
+
+"use strict";
+
+const { URL } = require("url");
+const { filterTokens } = require("markdownlint-rule-helpers");
+
+module.exports = {
+  "names": [ "any-blockquote" ],
+  "description": "Rule that reports an error for any blockquote",
+  "information": new URL(
+    "https://github.com/DavidAnson/markdownlint" +
+    "/blob/master/test/rules/any-blockquote.js"
+  ),
+  "tags": [ "test" ],
+  "function": (params, onError) => {
+    filterTokens(params, "blockquote_open", (blockquote) => {
+      const lines = blockquote.map[1] - blockquote.map[0];
+      onError({
+        "lineNumber": blockquote.lineNumber,
+        "detail": "Blockquote spans " + lines + " line(s).",
+        "context": blockquote.line.substr(0, 7)
+      });
+    });
+  }
+};

--- a/test/customRules-pre-imported/viewme.md
+++ b/test/customRules-pre-imported/viewme.md
@@ -1,0 +1,14 @@
+# Title
+
+> Tagline 
+
+
+# Description
+
+Text text text
+Text text text
+Text text text
+
+##  Summary
+
+Text text text

--- a/test/markdownItPlugins.stdout
+++ b/test/markdownItPlugins.stdout
@@ -1,3 +1,3 @@
 Finding: **/*.md
-Linting: 3 file(s)
+Linting: 4 file(s)
 Summary: 3 error(s)

--- a/test/markdownItPlugins/pre-imported/.markdownlint-cli2.js
+++ b/test/markdownItPlugins/pre-imported/.markdownlint-cli2.js
@@ -1,0 +1,18 @@
+// @ts-check
+
+"use strict";
+
+const markdownItForInline = require("markdown-it-for-inline");
+
+module.exports = {
+  "markdownItPlugins": [
+    [
+      markdownItForInline,
+      "trim_text_plugin",
+      "text",
+      function iterator(tokens, index) {
+        tokens[index].content = tokens[index].content.trim();
+      }
+    ]
+  ]
+};

--- a/test/markdownItPlugins/pre-imported/pre-imported.md
+++ b/test/markdownItPlugins/pre-imported/pre-imported.md
@@ -1,0 +1,3 @@
+# Heading
+
+Text [ link ](https://example.com)

--- a/test/markdownlint-cli2-test.js
+++ b/test/markdownlint-cli2-test.js
@@ -344,6 +344,12 @@ testCase({
 });
 
 testCase({
+  "name": "customRules-pre-imported",
+  "args": [ "**/*.md" ],
+  "exitCode": 1
+});
+
+testCase({
   "name": "customRules-missing",
   "args": [ ".*" ],
   "exitCode": 2,
@@ -412,6 +418,13 @@ testCase({
     fs.unlink(path.join(__dirname, dir, "custom-name.json")),
     fs.unlink(path.join(__dirname, dir, "custom-name.xml"))
   ])
+});
+
+testCase({
+  "name": "outputFormatters-pre-imported",
+  "args": [ "**/*.md" ],
+  "exitCode": 1,
+  "post": (dir) => fs.unlink(path.join(__dirname, dir, "custom-name.json"))
 });
 
 testCase({

--- a/test/outputFormatters-pre-imported.formatter.json
+++ b/test/outputFormatters-pre-imported.formatter.json
@@ -1,0 +1,93 @@
+[
+ {
+  "fileName": "viewme.md",
+  "lineNumber": 3,
+  "ruleNames": [
+   "MD009",
+   "no-trailing-spaces"
+  ],
+  "ruleDescription": "Trailing spaces",
+  "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/vX.Y.Z/doc/Rules.md#md009",
+  "errorDetail": "Expected: 0 or 2; Actual: 1",
+  "errorContext": null,
+  "errorRange": [
+   10,
+   1
+  ],
+  "fixInfo": {
+   "editColumn": 10,
+   "deleteCount": 1
+  }
+ },
+ {
+  "fileName": "viewme.md",
+  "lineNumber": 5,
+  "ruleNames": [
+   "MD012",
+   "no-multiple-blanks"
+  ],
+  "ruleDescription": "Multiple consecutive blank lines",
+  "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/vX.Y.Z/doc/Rules.md#md012",
+  "errorDetail": "Expected: 1; Actual: 2",
+  "errorContext": null,
+  "errorRange": null,
+  "fixInfo": {
+   "deleteCount": -1
+  }
+ },
+ {
+  "fileName": "viewme.md",
+  "lineNumber": 6,
+  "ruleNames": [
+   "MD025",
+   "single-title",
+   "single-h1"
+  ],
+  "ruleDescription": "Multiple top level headings in the same document",
+  "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/vX.Y.Z/doc/Rules.md#md025",
+  "errorDetail": null,
+  "errorContext": "# Description",
+  "errorRange": null,
+  "fixInfo": null
+ },
+ {
+  "fileName": "viewme.md",
+  "lineNumber": 12,
+  "ruleNames": [
+   "MD019",
+   "no-multiple-space-atx"
+  ],
+  "ruleDescription": "Multiple spaces after hash on atx style heading",
+  "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/vX.Y.Z/doc/Rules.md#md019",
+  "errorDetail": null,
+  "errorContext": "##  Summary",
+  "errorRange": [
+   1,
+   5
+  ],
+  "fixInfo": {
+   "editColumn": 3,
+   "deleteCount": 1
+  }
+ },
+ {
+  "fileName": "viewme.md",
+  "lineNumber": 14,
+  "ruleNames": [
+   "MD047",
+   "single-trailing-newline"
+  ],
+  "ruleDescription": "Files should end with a single newline character",
+  "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/vX.Y.Z/doc/Rules.md#md047",
+  "errorDetail": null,
+  "errorContext": null,
+  "errorRange": [
+   14,
+   1
+  ],
+  "fixInfo": {
+   "editColumn": 15,
+   "insertText": "\n"
+  }
+ }
+]

--- a/test/outputFormatters-pre-imported.stdout
+++ b/test/outputFormatters-pre-imported.stdout
@@ -1,0 +1,3 @@
+Finding: **/*.md
+Linting: 1 file(s)
+Summary: 5 error(s)

--- a/test/outputFormatters-pre-imported/.markdownlint-cli2.js
+++ b/test/outputFormatters-pre-imported/.markdownlint-cli2.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+"use strict";
+
+const formatterJson = require("../../formatter-json");
+
+module.exports = {
+  "outputFormatters": [
+    [ formatterJson, { "name": "custom-name.json", "spaces": 1 } ]
+  ]
+}

--- a/test/outputFormatters-pre-imported/viewme.md
+++ b/test/outputFormatters-pre-imported/viewme.md
@@ -1,0 +1,14 @@
+# Title
+
+> Tagline 
+
+
+# Description
+
+Text text text
+Text text text
+Text text text
+
+##  Summary
+
+Text text text


### PR DESCRIPTION
This allows for locally defined plugins and for sharing lists of plugins
that are used for linting and for directly passing to markdown-it
without repeating the name of the plugin.

In our environment, we have a couple different sets of plugins for
various uses.  To share the config between rendering and linting,
we moved the plugin list to a list with the need data including the
plugin itself.  This change lets us import that list from both places
and use it.