### PR TITLE
Add support for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: markdownlint-cli2
+    name: markdownlint-cli2
+    description: "Checks the style of Markdown/Commonmark files."
+    entry: markdownlint-cli2
+    language: node
+    types: [markdown]
+    minimum_pre_commit_version: 0.15.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
--   id: markdownlint-cli2
-    name: markdownlint-cli2
-    description: "Checks the style of Markdown/Commonmark files."
-    entry: markdownlint-cli2
-    language: node
-    types: [markdown]
-    minimum_pre_commit_version: 0.15.0
+- id: markdownlint-cli2
+  name: markdownlint-cli2
+  description: "Checks the style of Markdown/CommonMark files."
+  entry: markdownlint-cli2
+  language: node
+  types: [markdown]
+  minimum_pre_commit_version: 0.15.0


### PR DESCRIPTION
As was added in `markdownlint-cli`, I've reused the same configuration to allow support for `pre-commit` hook.