### PR TITLE
Wrap this tool in a container image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,13 @@
 FROM node:lts-alpine AS build
 WORKDIR /pack
-ADD --chown=1000 . .
+COPY --chown=1000 . .
 RUN npm pack
 
 FROM node:lts-alpine AS prod
-COPY --from=build /pack/markdownlint-cli2-*.tgz .
-RUN npm install --global --no-package-lock --production markdownlint-cli2-*.tgz
-RUN rm markdownlint-cli2-*.tgz
+# hadolint ignore=DL3010
+COPY --from=build /pack/markdownlint-cli2-*.tgz /
+RUN npm install --global --no-package-lock --production markdownlint-cli2-*.tgz && \
+    rm /markdownlint-cli2-*.tgz
 
 USER node
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts-alpine AS build
+WORKDIR /pack
+ADD --chown=1000 . .
+RUN npm pack
+
+FROM node:lts-alpine AS prod
+COPY --from=build /pack/markdownlint-cli2-*.tgz .
+RUN npm install --global --no-package-lock --production markdownlint-cli2-*.tgz
+RUN rm markdownlint-cli2-*.tgz
+
+USER node
+
+ENTRYPOINT ["/usr/local/bin/markdownlint-cli2"]

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   },
   "bugs": "https://github.com/DavidAnson/markdownlint-cli2/issues",
   "scripts": {
-    "ci": "npm-run-all --continue-on-error --parallel test-cover lint",
+    "ci": "npm-run-all --continue-on-error --parallel test-cover lint lint-dockerfile",
     "lint": "eslint --max-warnings 0 .",
+    "lint-dockerfile": "docker run --rm -i hadolint/hadolint:latest-alpine < docker/Dockerfile",
     "lint-watch": "git ls-files | entr npm run lint",
     "test": "ava test/append-to-array-test.js test/markdownlint-cli2-test.js test/markdownlint-cli2-test-exec.js test/markdownlint-cli2-test-main.js test/merge-options-test.js test/resolve-and-require-test.js",
     "test-cover": "c8 --check-coverage --branches 100 --functions 100 --lines 100 --statements 100 npm test",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint-watch": "git ls-files | entr npm run lint",
     "test": "ava test/append-to-array-test.js test/markdownlint-cli2-test.js test/markdownlint-cli2-test-exec.js test/markdownlint-cli2-test-main.js test/merge-options-test.js test/resolve-and-require-test.js",
     "test-cover": "c8 --check-coverage --branches 100 --functions 100 --lines 100 --statements 100 npm test",
-    "test-watch": "git ls-files | entr npm run test"
+    "test-watch": "git ls-files | entr npm run test",
+    "build-container": "docker build -t markdownlint-cli2:$SEMVAR -f docker/Dockerfile . && docker tag markdownlint-cli2:$SEMVAR markdownlint-cli2:latest"
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "ava test/append-to-array-test.js test/markdownlint-cli2-test.js test/markdownlint-cli2-test-exec.js test/markdownlint-cli2-test-main.js test/merge-options-test.js test/resolve-and-require-test.js",
     "test-cover": "c8 --check-coverage --branches 100 --functions 100 --lines 100 --statements 100 npm test",
     "test-watch": "git ls-files | entr npm run test",
-    "build-container": "docker build -t markdownlint-cli2:$SEMVAR -f docker/Dockerfile . && docker tag markdownlint-cli2:$SEMVAR markdownlint-cli2:latest"
+    "build-container": "docker build -t DavidAnson/markdownlint-cli2:$SEMVAR -f docker/Dockerfile . && docker tag DavidAnson/markdownlint-cli2:$SEMVAR DavidAnson/markdownlint-cli2:latest"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
Using the new `docker/Dockerfile`, create a container image where `markdownlint-cli2` is installed globally and is also set as the default entrypoint. This makes usage of this image for linting MD files identical to using `markdownlint-cli2` directly:

```bash
$ docker run --rm -v $PWD:/workdir -w /workdir DavidAnson/markdownlint-cli2:latest "**/*.md" "#node_modules"
```

2 new scripts were added to the `package.json`. Both of these new scripts assume you have [Docker](https://www.docker.com/) installed:

1. `build-container`: which uses `docker` to build the container and tag it with `latest` as well as with a version defined by `$SEMVAR`

    Call it like so (or find a way to automate setting the `$SEMVAR` before calling it)

    ```bash
    $ SEMVAR=0.2.0 npm run build-container
    ```

    The above command will produce an image with 2 tags:
    - `DavidAnson/markdownlint-cli2:0.2.0`
    - `DavidAnson/markdownlint-cli2:latest`

2. `lint-dockerfile`: which uses a very popular `Dockerfile` linter, [`hadolint`](https://github.com/hadolint/hadolint), to lint `docker/Dockerfile`.

    You can call it on its own like so:
    ```bash
    $ npm run lint-dockerfile
    ```
   but I also added it to the existing `ci` script:
    ```bash
    $ npm run ci
    ```

What's remaining is the publication of the built image (both tags) to a public registry. Obviously I would suggest https://hub.docker.com for the most exposure. DockerHub allows any free account unlimited _public_ repositories (images) and only 1 _private_ one by default. In this case, we would want the created repository to be _public_.

For now, the above `build-container` script assumes your username on DockerHub is `DavidAnson` and therefore prefixes the image with it (a standard DockerHub convention). If your username is anything other than `DavidAnson` you will need to update the `build-container` script to prefix the tags accordingly.

Once you've settled on a username and updated the `build-container` script accordingly, a new publication script could be added to the `package.json`, e.g.:

```json
  "scripts":
    ...
    "publish-container": "docker push DavidAnson/markdownlint-cli2:$SEMVAR && docker push DavidAnson/markdownlint-cli2:latest"
```

The above script makes the following assumptions:

1. You've previously called the `build-container` script which created/updated the image tags `$SEMVAR` and `latest`.
2. You're already logged in (authenticated) to DockerHub (done by calling `docker login`).
3. You will also call this `publish-container` script by providing the `$SEMVAR` variable, e.g.:

    ```bash
    $ SEMVAR=0.2.0 npm run publish-container
    ```

4. Again, that your username on DockerHub is `DavidAnson` (update the script otherwise)

If you're so inclined, you might want to add some labels to the built container image (see the [Dockerfile LABEL command reference](https://docs.docker.com/engine/reference/builder/#label)).

This PR closes #27.
