### PR TITLE
Use path.resolve in outputformatters

### DIFF
--- a/formatter-json/markdownlint-cli2-formatter-json.js
+++ b/formatter-json/markdownlint-cli2-formatter-json.js
@@ -11,7 +11,7 @@ const outputFormatter = (options, params) => {
   const { name, spaces } = (params || {});
   const content = JSON.stringify(results, null, spaces || 2);
   return fs.writeFile(
-    path.join(
+    path.resolve(
       // eslint-disable-next-line no-inline-comments
       directory /* c8 ignore next */ || "",
       name || "markdownlint-cli2-results.json"

--- a/formatter-junit/markdownlint-cli2-formatter-junit.js
+++ b/formatter-junit/markdownlint-cli2-formatter-junit.js
@@ -42,7 +42,7 @@ const outputFormatter = (options, params) => {
   }
   const content = builder.build();
   return fs.writeFile(
-    path.join(
+    path.resolve(
       // eslint-disable-next-line no-inline-comments
       directory /* c8 ignore next */ || "",
       name || "markdownlint-cli2-junit.xml"


### PR DESCRIPTION
As discussed in #38, using path.resolve() instead of path.join() when determining where to write the output file.