### PR TITLE
Fix container image tag typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ A container image [`davidanson/markdownlint-cli2`][docker-hub-markdownlint-cli2]
 can also be used (e.g., as part of a CI pipeline):
 
 ```bash
-docker run -v $PWD:/workdir davidanson/markdownlint-cli2:0.5.1 "**/*.md" "#node_modules"
+docker run -v $PWD:/workdir davidanson/markdownlint-cli2:v0.5.1 "**/*.md" "#node_modules"
 ```
 
 Notes:
@@ -148,14 +148,14 @@ Notes:
   - A custom working directory can be specified with Docker's `-w` flag:
 
     ```bash
-    docker run -w /myfolder -v $PWD:/myfolder davidanson/markdownlint-cli2:0.5.1 "**/*.md" "#node_modules"
+    docker run -w /myfolder -v $PWD:/myfolder davidanson/markdownlint-cli2:v0.5.1 "**/*.md" "#node_modules"
     ```
 
 To invoke the `markdownlint-cli2-config` or `markdownlint-cli2-fix` commands
 instead, use Docker's `--entrypoint` flag:
 
 ```bash
-docker run -v $PWD:/workdir --entrypoint="markdownlint-cli2-fix" davidanson/markdownlint-cli2:0.5.1 "**/*.md" "#node_modules"
+docker run -v $PWD:/workdir --entrypoint="markdownlint-cli2-fix" davidanson/markdownlint-cli2:v0.5.1 "**/*.md" "#node_modules"
 ```
 
 ### Exit Codes


### PR DESCRIPTION
Based on the output below, I think `...:0.5.1` should be `...:v0.5.1`.
```sh
[jan@framey roc]$ sudo docker pull davidanson/markdownlint-cli2:v0.5.1v0.5.1: Pulling from davidanson/markdownlint-cli2
Digest: sha256:d3bb9ef707ff8b34d57c96aadd54359f38cfcca54461435d00d9eb97c3bf12b6
Status: Downloaded newer image for davidanson/markdownlint-cli2:v0.5.1
docker.io/davidanson/markdownlint-cli2:v0.5.1
[jan@framey roc]$ sudo docker pull davidanson/markdownlint-cli2:0.5.1
Error response from daemon: manifest for davidanson/markdownlint-cli2:0.5.1 not found: manifest unknown: manifest unknown
[jan@framey roc]$ 
```