### PR TITLE
chore: replace ESLint plugin node with n

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,11 +8,12 @@
     "es6": true
   },
   "plugins": [
-    "node",
+    "n",
     "unicorn"
   ],
   "extends": [
     "eslint:all",
+    "plugin:n/recommended",
     "plugin:unicorn/all"
   ],
   "ignorePatterns": [
@@ -20,12 +21,6 @@
     "webworker/markdownlint-cli2-webworker.js"
   ],
   "reportUnusedDisableDirectives": true,
-  "overrides": [
-    {
-      "files": [ "webworker/*.js "],
-      "reportUnusedDisableDirectives": false
-    }
-  ],
   "rules": {
     "array-bracket-spacing": ["error", "always"],
     "array-element-newline": "off",
@@ -56,55 +51,43 @@
     "require-atomic-updates": "off",
     "sort-keys": "off",
 
-    "node/handle-callback-err": "error",
-    "node/no-callback-literal": "error",
-    "node/no-exports-assign": "error",
-    "node/no-extraneous-import": "error",
-    "node/no-extraneous-require": "error",
-    "node/no-missing-import": ["error", {
-      "allowModules": [
-        "chalk"
-      ]
-    }],
-    "node/no-missing-require": ["error", {
-      "allowModules": [
-        "ava"
-      ]
-    }],
-    "node/no-new-require": "error",
-    "node/no-path-concat": "error",
-    "node/no-process-exit": "error",
-    "node/no-unpublished-bin": "error",
-    "node/no-unpublished-import": "error",
-    "node/no-unpublished-require": "off",
-    "node/no-unsupported-features/es-builtins": "error",
-    "node/no-unsupported-features/es-syntax": "error",
-    "node/no-unsupported-features/node-builtins": ["error", {
-      "ignores": [
-        "fs.promises"
-      ]
-    }],
-    "node/process-exit-as-throw": "error",
-    "node/shebang": "error",
-    "node/no-deprecated-api": "error",
-    "node/callback-return": "error",
-    "node/exports-style": "error",
-    "node/file-extension-in-import": "error",
-    "node/global-require": "off",
-    "node/no-mixed-requires": "error",
-    "node/no-process-env": "error",
-    "node/no-restricted-import": "error",
-    "node/no-restricted-require": "error",
-    "node/no-sync": "error",
-    "node/prefer-global/buffer": "error",
-    "node/prefer-global/console": "error",
-    "node/prefer-global/process": "error",
-    "node/prefer-global/text-decoder": "error",
-    "node/prefer-global/text-encoder": "error",
-    "node/prefer-global/url-search-params": "error",
-    "node/prefer-global/url": "error",
-    "node/prefer-promises/dns": "error",
-    "node/prefer-promises/fs": "error",
+    "n/handle-callback-err": "error",
+    "n/no-callback-literal": "error",
+    "n/no-exports-assign": "error",
+    "n/no-extraneous-import": "error",
+    "n/no-extraneous-require": "error",
+    "n/no-missing-import": "error",
+    "n/no-missing-require": "error",
+    "n/no-new-require": "error",
+    "n/no-path-concat": "error",
+    "n/no-process-exit": "error",
+    "n/no-unpublished-bin": "error",
+    "n/no-unpublished-import": "error",
+    "n/no-unpublished-require": "error",
+    "n/no-unsupported-features/es-builtins": "error",
+    "n/no-unsupported-features/es-syntax": "error",
+    "n/no-unsupported-features/node-builtins": "error",
+    "n/process-exit-as-throw": "error",
+    "n/shebang": "error",
+    "n/no-deprecated-api": "error",
+    "n/callback-return": "error",
+    "n/exports-style": "error",
+    "n/file-extension-in-import": "error",
+    "n/global-require": "off",
+    "n/no-mixed-requires": "error",
+    "n/no-process-env": "error",
+    "n/no-restricted-import": "error",
+    "n/no-restricted-require": "error",
+    "n/no-sync": "error",
+    "n/prefer-global/buffer": "error",
+    "n/prefer-global/console": "error",
+    "n/prefer-global/process": "error",
+    "n/prefer-global/text-decoder": "error",
+    "n/prefer-global/text-encoder": "error",
+    "n/prefer-global/url-search-params": "error",
+    "n/prefer-global/url": "error",
+    "n/prefer-promises/dns": "error",
+    "n/prefer-promises/fs": "error",
 
     "unicorn/no-null": "off",
     "unicorn/prefer-module": "off",

--- a/formatter-pretty/markdownlint-cli2-formatter-pretty.js
+++ b/formatter-pretty/markdownlint-cli2-formatter-pretty.js
@@ -7,9 +7,7 @@
 const outputFormatter = async (options, params) => {
   const { results, logError } = options;
   const { appendLink } = (params || {});
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   const { "default": chalk } = await import("chalk");
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   const { "default": terminalLink } = await import("terminal-link");
   for (const errorInfo of results) {
     const { fileName, lineNumber, ruleNames, ruleDescription, ruleInformation,

--- a/formatter-pretty/package.json
+++ b/formatter-pretty/package.json
@@ -26,5 +26,8 @@
   },
   "keywords": [
     "markdownlint-cli2-formatter"
-  ]
+  ],
+  "engines": {
+    "node": ">=14.18.0"
+  }
 }

--- a/markdownlint-cli2.js
+++ b/markdownlint-cli2.js
@@ -34,8 +34,7 @@ const noop = () => null;
 // Gets a synchronous function to parse JSONC text
 const getJsoncParse = async () => {
   const { "default": stripJsonComments } =
-    // eslint-disable-next-line max-len
-    // eslint-disable-next-line no-inline-comments, node/no-unsupported-features/es-syntax
+    // eslint-disable-next-line no-inline-comments
     await import(/* webpackMode: "eager" */ "strip-json-comments");
   return (text) => JSON.parse(stripJsonComments(text));
 };
@@ -79,8 +78,7 @@ const importOrRequireResolve = async (dir, id) => {
     try {
       const fileUrlString =
         pathToFileURL(path.resolve(dir, expandId)).toString();
-      // eslint-disable-next-line max-len
-      // eslint-disable-next-line no-inline-comments, node/no-unsupported-features/es-syntax
+      // eslint-disable-next-line no-inline-comments
       const module = await import(/* webpackIgnore: true */ fileUrlString);
       return module.default;
     } catch (error) {
@@ -446,8 +444,7 @@ async (fs, baseDirSystem, baseDir, globPatterns, dirToDirInfo, noErrors, noRequi
     })
   );
   // Process glob patterns
-  // eslint-disable-next-line max-len
-  // eslint-disable-next-line no-inline-comments, node/no-unsupported-features/es-syntax
+  // eslint-disable-next-line no-inline-comments
   const { globby } = await import(/* webpackMode: "eager" */ "globby");
   const files = [
     ...await globby(expandedDirectories, globbyOptions),

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "cpy": "9.0.1",
     "del": "7.0.0",
     "eslint": "8.25.0",
-    "eslint-plugin-node": "11.1.0",
+    "eslint-plugin-n": "15.3.0",
     "eslint-plugin-unicorn": "44.0.2",
     "execa": "6.1.0",
     "markdown-it-emoji": "2.0.2",

--- a/test/markdownlint-cli2-test-cases.js
+++ b/test/markdownlint-cli2-test-cases.js
@@ -88,7 +88,6 @@ const testCases =
 
   const directoryName = (dir) => `${dir}-copy-${host}`;
 
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   const copyDirectory = (dir) => import("cpy").then((cpy) => (
     cpy.default(
       path.join(__dirname, dir, "**"),
@@ -96,7 +95,6 @@ const testCases =
     )
   ));
 
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   const deleteDirectory = (dir) => import("del").then((del) => (
     del.deleteAsync(path.join(__dirname, directoryName(dir)))
   ));

--- a/test/markdownlint-cli2-test-exec.js
+++ b/test/markdownlint-cli2-test-exec.js
@@ -6,7 +6,6 @@ const path = require("node:path");
 const testCases = require("./markdownlint-cli2-test-cases");
 
 const invoke = (directory, args, noRequire, env, script) => async () => {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   const { execaNode } = await import("execa");
   return execaNode(
     path.join(__dirname, "..", script || "markdownlint-cli2.js"),

--- a/test/resolve-and-require-test.js
+++ b/test/resolve-and-require-test.js
@@ -6,7 +6,7 @@ const test = require("ava").default;
 const path = require("node:path");
 const resolveAndRequire = require("../resolve-and-require");
 
-/* eslint-disable node/no-missing-require */
+/* eslint-disable n/no-missing-require */
 
 test("built-in module", (t) => {
   t.plan(1);

--- a/webworker/process-wrapper.js
+++ b/webworker/process-wrapper.js
@@ -2,9 +2,7 @@
 
 "use strict";
 
-/* eslint-disable node/no-extraneous-require,node/no-missing-require */
-
-// eslint-disable-next-line unicorn/prefer-node-protocol
+// eslint-disable-next-line unicorn/prefer-node-protocol, n/no-missing-require
 const processBrowser = require("process/browser");
 processBrowser.versions = {
   "node": "0.0"

--- a/webworker/webpack.config.js
+++ b/webworker/webpack.config.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-/* eslint-disable node/no-extraneous-require,node/no-missing-require */
+/* eslint-disable n/no-missing-require */
 
 const webpack = require("webpack");
 const nodeModulePrefixRe = /^node:/u;

--- a/webworker/webworker-test.js
+++ b/webworker/webworker-test.js
@@ -1,5 +1,8 @@
 "use strict";
 
+/* eslint-env qunit */
+/* globals markdownlintCli2, FsVirtual */
+
 const oneViolation = "# Title\n\nText \n";
 const twoViolations = "# Title\n\nText\t\n";
 const noViolationsIgnoringTabs = "# Title\n\n\tText\n";
@@ -21,8 +24,6 @@ const outputFormatterLengthIs = (assert, length) => (options) => {
   const { results } = options;
   assert.equal(Object.keys(results).length, length);
 };
-
-/* eslint-disable no-undef */
 
 QUnit.test("script loads", (assert) => {
   assert.expect(1);


### PR DESCRIPTION
The `eslint-plugin-node` stopped getting updates a little while ago, so a fork was taken into the ESLint Community or to continue support https://github.com/eslint-community/eslint-plugin-n