### PR TITLE
chore: add version when using github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ As a [GitHub Action][github-action] via
 
 ```yaml
 - name: markdownlint-cli2-action
-  uses: DavidAnson/markdownlint-cli2-action
+  uses: DavidAnson/markdownlint-cli2-action@main
 ```
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ As a [GitHub Action][github-action] via
 
 ```yaml
 - name: markdownlint-cli2-action
-  uses: DavidAnson/markdownlint-cli2-action@main
+  uses: DavidAnson/markdownlint-cli2-action@v9
 ```
 
 ## Overview


### PR DESCRIPTION
When using the readme example for github actions, the below error occurs:

![image](https://user-images.githubusercontent.com/46422437/221429739-feb38937-9c5b-49cd-bf75-0ce24d39df22.png)

When passing "v9" as version, it works perfectly:

![image](https://user-images.githubusercontent.com/46422437/221429800-6c7b4942-a3af-40c9-9218-b82c9fc458c6.png)
