### PR TITLE
feat: add markdownlint-rule-github-admonition to rules docker image

### DIFF
--- a/docker/Dockerfile-rules
+++ b/docker/Dockerfile-rules
@@ -7,6 +7,7 @@ RUN npm install --global --no-package-lock --production \
     @github/markdownlint-github \
     markdownlint-rule-enhanced-proper-names \
     markdownlint-rule-github-internal-links \
+    markdownlint-rule-github-admonition \
     markdownlint-rule-header-id \
     markdownlint-rule-list-duplicates \
     markdownlint-rule-max-one-sentence-per-line \

--- a/docker/Dockerfile-rules
+++ b/docker/Dockerfile-rules
@@ -6,8 +6,8 @@ USER root
 RUN npm install --global --no-package-lock --production \
     @github/markdownlint-github \
     markdownlint-rule-enhanced-proper-names \
-    markdownlint-rule-github-internal-links \
     markdownlint-rule-github-admonition \
+    markdownlint-rule-github-internal-links \
     markdownlint-rule-header-id \
     markdownlint-rule-list-duplicates \
     markdownlint-rule-max-one-sentence-per-line \


### PR DESCRIPTION
[GitHub Admonition markdownlint rule](https://github.com/aepfli/markdownlint-rule-github-admonition) was released a few days ago. It allows us to detect and fix GitHub-style admonitions.

With this pull request we also include it into the rules docker image.