### PR TITLE
ci: skip double build for Dependabot PRs

### DIFF
--- a/.github/workflows/checkers.yml
+++ b/.github/workflows/checkers.yml
@@ -3,6 +3,8 @@ name: Checkers
 on:
   pull_request:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   schedule:
   - cron: '30 12 * * *'
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   schedule:
     - cron: '30 12 * * *'
   workflow_dispatch:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,6 +3,8 @@ name: CodeQL
 on:
   pull_request:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   schedule:
     - cron: '30 12 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Since Dependabot submits its changes through PRs, it doesn't need to also build on the branch pushes