### PR TITLE
Bump yaml from 2.2.1 to 2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "markdownlint-cli2-formatter-default": "0.0.4",
     "micromatch": "4.0.5",
     "strip-json-comments": "5.0.0",
-    "yaml": "2.2.1"
+    "yaml": "2.2.2"
   },
   "devDependencies": {
     "@iktakahiro/markdown-it-katex": "4.0.1",


### PR DESCRIPTION
- https://github.com/advisories/GHSA-f9xv-q969-pqx4