### PR TITLE
chore: Move Dependabot to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     target-branch: "next"
     versioning-strategy: "increase"


### PR DESCRIPTION
There is also a "weekly" cadence, but I figured since there aren't weekly releases of the package that it is probably OK to reduce the frequency/noise of these PRs