### PR TITLE
fix: update junit-report-builder to v3.0.1

### DIFF
--- a/formatter-junit/package.json
+++ b/formatter-junit/package.json
@@ -21,7 +21,7 @@
     "markdownlint-cli2": ">=0.0.4"
   },
   "dependencies": {
-    "junit-report-builder": "3.0.0"
+    "junit-report-builder": "3.0.1"
   },
   "keywords": [
     "markdownlint-cli2-formatter"


### PR DESCRIPTION
Hello! :wave:

Currently when installing `markdownlint-cli2` with `npm` it yields to this warning message:

```sh
npm WARN deprecated date-format@0.0.2: 0.x is no longer supported. Please upgrade to 4.x or higher.
````

We can see to what it come from with:
```sh
$ npm why date-format
date-format@0.0.2 extraneous
node_modules/markdownlint-cli2/node_modules/date-format
  date-format@"0.0.2" from junit-report-builder@3.0.0
  node_modules/markdownlint-cli2/node_modules/junit-report-builder
    junit-report-builder@"3.0.0" from markdownlint-cli2-formatter-junit@0.0.6
    node_modules/markdownlint-cli2/node_modules/markdownlint-cli2-formatter-junit
```

`date-format` has been updated in v3.0.1 of `junit-report-builder` (ref: https://github.com/davidparsson/junit-report-builder#301 and https://github.com/davidparsson/junit-report-builder/pull/34), hence fixing the warning. :smile: