### PR TITLE
fix: allowTrailingCommas in JSONC config

### DIFF
--- a/schema/markdownlint-cli2-config-schema.json
+++ b/schema/markdownlint-cli2-config-schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/v0.12.1/schema/markdownlint-cli2-config-schema.json",
+  "allowTrailingCommas": true,
   "title": "markdownlint-cli2 configuration schema",
   "type": "object",
   "properties": {

--- a/test/markdownlint-cli2-test.js
+++ b/test/markdownlint-cli2-test.js
@@ -116,6 +116,7 @@ test("validateMarkdownlintCli2ConfigSchema", async (t) => {
     "allowUnionTypes": true,
     "strictTuples": false
   });
+  ajv.addKeyword("allowTrailingCommas");
   ajv.addSchema(markdownlintConfigSchemaDefinition);
   const validateConfigSchema = ajv.compile(markdownlintCli2ConfigSchemaDefinition);
   t.is(


### PR DESCRIPTION
This allows trailling commas in the `.markdownlint-cli2.jsonc` configuration file.

Related issues: https://github.com/DavidAnson/markdownlint-cli2/issues/267, https://github.com/microsoft/vscode/issues/202422