### PR TITLE
HOTFIX: Updating micromatch@4.0.5 to @4.0.6 due to vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jsonc-parser": "3.2.1",
     "markdownlint": "0.34.0",
     "markdownlint-cli2-formatter-default": "0.0.4",
-    "micromatch": "4.0.5"
+    "micromatch": "4.0.6"
   },
   "devDependencies": {
     "@iktakahiro/markdown-it-katex": "4.0.1",


### PR DESCRIPTION
[There is a vulnerability in micromatch@4.0.5](https://github.com/micromatch/micromatch/blob/2c56a8604b68c1099e7bc0f807ce0865a339747a/index.js#L448). This is fixed with the version @4.0.6 with [this pull request](https://github.com/micromatch/micromatch/pull/247)

More information about this vulnerability can be found [here](https://github.com/micromatch/micromatch/issues/243)

Ran tests. All passed.