### PR TITLE
Add support for .markdownlint-cli2.yml

### DIFF
--- a/markdownlint-cli2.js
+++ b/markdownlint-cli2.js
@@ -320,6 +320,7 @@ const getAndProcessDirInfo = (
     // Load markdownlint-cli2 object(s)
     const markdownlintCli2Jsonc = pathPosix.join(dir, ".markdownlint-cli2.jsonc");
     const markdownlintCli2Yaml = pathPosix.join(dir, ".markdownlint-cli2.yaml");
+    const markdownlintCli2Yml = pathPosix.join(dir, ".markdownlint-cli2.yml");
     const markdownlintCli2Cjs =  pathPosix.join(dir, ".markdownlint-cli2.cjs");
     const markdownlintCli2Mjs = pathPosix.join(dir, ".markdownlint-cli2.mjs");
     const packageJson = pathPosix.join(dir, "package.json");
@@ -333,23 +334,27 @@ const getAndProcessDirInfo = (
           () => fs.promises.access(captureFile(markdownlintCli2Yaml)).
             then(
               () => fs.promises.readFile(file, utf8).then(getYamlParse()),
-              () => fs.promises.access(captureFile(markdownlintCli2Cjs)).
+              () => fs.promises.access(captureFile(markdownlintCli2Yml)).
                 then(
-                  () => importOrRequireResolve(dir, file, noRequire),
-                  () => fs.promises.access(captureFile(markdownlintCli2Mjs)).
+                  () => fs.promises.readFile(file, utf8).then(getYamlParse()),
+                  () => fs.promises.access(captureFile(markdownlintCli2Cjs)).
                     then(
                       () => importOrRequireResolve(dir, file, noRequire),
-                      () => (allowPackageJson
-                        ? fs.promises.access(captureFile(packageJson))
-                        // eslint-disable-next-line prefer-promise-reject-errors
-                        : Promise.reject()
-                      ).
+                      () => fs.promises.access(captureFile(markdownlintCli2Mjs)).
                         then(
-                          () => fs.promises.
-                            readFile(file, utf8).
-                            then(getJsoncParse()).
-                            then((obj) => obj[packageName]),
-                          noop
+                          () => importOrRequireResolve(dir, file, noRequire),
+                          () => (allowPackageJson
+                            ? fs.promises.access(captureFile(packageJson))
+                            // eslint-disable-next-line prefer-promise-reject-errors
+                            : Promise.reject()
+                          ).
+                            then(
+                              () => fs.promises.
+                                readFile(file, utf8).
+                                then(getJsoncParse()).
+                                then((obj) => obj[packageName]),
+                              noop
+                            )
                         )
                     )
                 )

--- a/markdownlint-cli2.js
+++ b/markdownlint-cli2.js
@@ -170,7 +170,10 @@ const readOptionsOrConfig = async (configPath, fs, noRequire) => {
   try {
     if (basename.endsWith(".markdownlint-cli2.jsonc")) {
       options = getJsoncParse()(await fs.promises.readFile(configPath, utf8));
-    } else if (basename.endsWith(".markdownlint-cli2.yaml")) {
+    } else if (
+      basename.endsWith(".markdownlint-cli2.yaml") ||
+      basename.endsWith(".markdownlint-cli2.yml")
+    ) {
       options = getYamlParse()(await fs.promises.readFile(configPath, utf8));
     } else if (
       basename.endsWith(".markdownlint-cli2.cjs") ||


### PR DESCRIPTION
Now supports `.yml` extension for config file.

All tests passed.

Works fine in my own environment.

#392 