### PR TITLE
micromatch 4.0.8 fix CVE-2024-4067

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jsonc-parser": "3.2.1",
     "markdownlint": "0.34.0",
     "markdownlint-cli2-formatter-default": "0.0.4",
-    "micromatch": "4.0.5"
+    "micromatch": "4.0.8"
   },
   "devDependencies": {
     "@iktakahiro/markdown-it-katex": "4.0.1",


### PR DESCRIPTION
4.0.5...4.0.7 has a ReDOS vulnerability called CVE-2024-4067 , see https://github.com/advisories/GHSA-952p-6rrq-rcjv

> hans@LAPTOP-O1AO16UE:~/projects/hestiacp$ npm audit # npm audit report
> 
> micromatch  <4.0.8
> Severity: moderate
> Regular Expression Denial of Service (ReDoS) in micromatch - https://github.com/advisories/GHSA-952p-6rrq-rcjv fix available via `npm audit fix --force`
> Will install markdownlint-cli2@0.3.2, which is a breaking change node_modules/lint-staged/node_modules/micromatch
> node_modules/micromatch
> node_modules/stylelint/node_modules/micromatch
>   markdownlint-cli2  >=0.4.0
>   Depends on vulnerable versions of micromatch
>   node_modules/markdownlint-cli2
> 
> 2 moderate severity vulnerabilities