### PR TITLE
Use UID number rather than username in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,11 @@ COPY --from=build /pack/markdownlint-cli2-*.tgz /
 RUN npm install --global --no-package-lock --production /markdownlint-cli2-*.tgz
 RUN rm /markdownlint-cli2-*.tgz
 
-USER node
+# "1000" is the documented UID for the "node" user: https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user
+# Systems configured to disallow running images as root aren't able to run images that use user name string values for the USER because they can't validate that a named user isn't root.
+# To allow this image to run on such systems, use the uid of the user as the value for USER instead of the username.
+# See https://github.com/kubernetes/kubernetes/pull/56503
+USER 1000
 
 WORKDIR /workdir
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,11 +18,9 @@ COPY --from=build /pack/markdownlint-cli2-*.tgz /
 RUN npm install --global --no-package-lock --production /markdownlint-cli2-*.tgz
 RUN rm /markdownlint-cli2-*.tgz
 
-# "1000" is the documented UID for the "node" user: https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user
-# Systems configured to disallow running images as root aren't able to run images that use user name string values for the USER because they can't validate that a named user isn't root.
-# To allow this image to run on such systems, use the uid of the user as the value for USER instead of the username.
-# See https://github.com/kubernetes/kubernetes/pull/56503
 USER 1000
+# 1000 is the documented user ID for the unprivileged "node" user: https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user
+# Kubernetes running as non-root requires user ID (implied by the docs for "runAsUser"): https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#securitycontext-v1-core
 
 WORKDIR /workdir
 


### PR DESCRIPTION
Systems configured to disallow running images as root aren't able to run images that use user name string values for the `USER` because they can't validate that a named user isn't root. To allow this image to run on such systems, use the uid of the user as the value for `USER` instead of the username.

See: https://github.com/kubernetes/kubernetes/pull/56503