### PR TITLE
feat: toml as a config source

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Configuration via:
 - .markdownlint.yaml or .markdownlint.yml
 - .markdownlint.cjs or .markdownlint.mjs
 - package.json
+- .markdownlint-cli2.toml
+- .markdownlint.toml
 
 Cross-platform compatibility:
 - UNIX and Windows shells expand globs according to different rules; quoting arguments is recommended
@@ -112,8 +114,8 @@ $ markdownlint-cli2 "**/*.md" "#node_modules"
 ```
 
 For scenarios where it is preferable to specify glob expressions in a
-configuration file, the `globs` property of `.markdownlint-cli2.jsonc`, `.yaml`,
-`.cjs`, or `.mjs` may be used instead of (or in addition to) passing
+configuration file, the `globs` property of `.markdownlint-cli2.jsonc`, `.toml`,
+`.yaml`, `.cjs`, or `.mjs` may be used instead of (or in addition to) passing
 `glob0 ... globN` on the command-line.
 
 As shown above, a typical command-line for `markdownlint-cli2` looks something
@@ -257,6 +259,7 @@ supported by the `--format` command-line parameter. When `--format` is set:
       3. `.markdownlint-cli2.cjs`
       4. `.markdownlint-cli2.mjs`
       5. `package.json` (only supported in the current directory)
+      6. `.markdownlint-cli2.toml`
   - Configuration files like `.markdownlint.*` allow control over only the
     `markdownlint` `config` object and tend to be supported more broadly (such
     as by `markdownlint-cli`).
@@ -268,6 +271,7 @@ supported by the `--format` command-line parameter. When `--format` is set:
       4. `.markdownlint.yml`
       5. `.markdownlint.cjs`
       6. `.markdownlint.mjs`
+      7. `.markdownlint.toml`
 - The VS Code extension includes a [JSON Schema][json-schema] definition for the
   `JSON(C)` configuration files described below. This adds auto-complete and can
   make it easier to define proper structure.
@@ -282,10 +286,13 @@ supported by the `--format` command-line parameter. When `--format` is set:
 - Valid properties are:
   - `config`: [`markdownlint` `config` object][markdownlint-config] to configure
     rules for this part of the directory tree
-    - If a `.markdownlint.{jsonc,json,yaml,yml,js}` file (see below) is present
+    - If a `.markdownlint.{jsonc,json,toml,yaml,yml,cjs,mjs}` file (see below)
+      is present
       in the same directory, it overrides the value of this property
     - If the `config` object contains an `extends` property, it will be resolved
-      the same as `.markdownlint.{jsonc,json,yaml,yml,js}` (see below)
+      the same as `.markdownlint.{jsonc,json,toml,yaml,yml,cjs,mjs}` (see
+      below) and can
+      also reference `.toml` files (for example `pyproject.toml`)
   - `customRules`: `Array` of `String`s (or `Array`s of `String`s) of module
     names/paths of [custom rules][markdownlint-custom-rules] to load and use
     when linting
@@ -377,6 +384,16 @@ supported by the `--format` command-line parameter. When `--format` is set:
 - For example: [`.markdownlint-cli2.jsonc`][markdownlint-cli2-jsonc] with all
   properties set
 
+### `.markdownlint-cli2.toml`
+
+- The format of this file is a [TOML][toml] object with the structure described
+  above for `.markdownlint-cli2.jsonc`.
+- For convenience, a `[markdownlint]` table is also recognized and mapped to
+  the `config` property.
+- The `markdownlint` table can be nested (for example
+  `[tool.markdownlint.MD013]`).
+- Other details are the same as for `.markdownlint-cli2.jsonc` described above.
+
 ### `.markdownlint-cli2.yaml`
 
 - The format of this file is a [YAML][yaml] object with the structure described
@@ -417,6 +434,14 @@ supported by the `--format` command-line parameter. When `--format` is set:
   property (documented in the link above).
 - Both file types support comments in JSON.
 - For example: [`.markdownlint.jsonc`][markdownlint-jsonc]
+
+### `.markdownlint.toml`
+
+- The format of this file is a [TOML][toml] object representing the
+  [`markdownlint` `config` object][markdownlint-config].
+- A `[markdownlint]` table is supported for this file type.
+- The `markdownlint` table can be nested (for example
+  `[any.markdownlint.MD013]` or `[*.markdownlint.MD013]`) .
 
 ### `.markdownlint.yaml` or `.markdownlint.yml`
 
@@ -525,6 +550,7 @@ See [CHANGELOG.md][changelog].
 [pre-commit-version]: https://pre-commit.com/#overriding-language-version
 [regexp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
 [regexp-constructor]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp
+[toml]: https://toml.io/
 [validating-configuration]: schema/ValidatingConfiguration.md
 [vscode]: https://code.visualstudio.com/
 [vscode-markdownlint]: https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "merge-options.mjs",
     "parsers/parsers.mjs",
     "parsers/jsonc-parse.mjs",
+    "parsers/toml-parse.mjs",
     "parsers/yaml-parse.mjs",
     "README.md",
     "schema/markdownlint-cli2-config-schema.json",
@@ -79,6 +80,7 @@
     "markdownlint": "0.40.0",
     "markdownlint-cli2-formatter-default": "0.0.6",
     "markdown-it": "14.1.1",
+    "smol-toml": "1.4.2",
     "micromatch": "4.0.8"
   },
   "devDependencies": {

--- a/parsers/parsers.mjs
+++ b/parsers/parsers.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 
 import jsoncParse from "./jsonc-parse.mjs";
+import tomlParse from "./toml-parse.mjs";
 import yamlParse from "./yaml-parse.mjs";
 
 /**
@@ -9,6 +10,7 @@ import yamlParse from "./yaml-parse.mjs";
  */
 const parsers = [
   jsoncParse,
+  tomlParse,
   yamlParse
 ];
 

--- a/parsers/toml-parse.mjs
+++ b/parsers/toml-parse.mjs
@@ -1,0 +1,38 @@
+// @ts-check
+
+import toml from "smol-toml";
+
+const isObject = (/** @type {any} */ value) => Boolean(value) && (typeof value === "object") && !Array.isArray(value);
+
+const findMarkdownlintConfig = (/** @type {any} */ value) => {
+  if (!isObject(value)) {
+    return null;
+  }
+  if (isObject(value.markdownlint)) {
+    return value.markdownlint;
+  }
+  for (const nestedValue of Object.values(value)) {
+    const markdownlintConfig = findMarkdownlintConfig(nestedValue);
+    if (markdownlintConfig) {
+      return markdownlintConfig;
+    }
+  }
+  return null;
+};
+
+/**
+ * Parses a TOML string, returning the corresponding object.
+ * @type {import("markdownlint").ConfigurationParser}
+ */
+const tomlParse = (text) => {
+  const parsed = toml.parse(text);
+  const pyprojectMarkdownlintConfig = findMarkdownlintConfig(parsed);
+  return (
+    (pyprojectMarkdownlintConfig && (typeof pyprojectMarkdownlintConfig === "object") && !Array.isArray(pyprojectMarkdownlintConfig)) ?
+      pyprojectMarkdownlintConfig :
+      parsed
+  );
+};
+
+export { findMarkdownlintConfig };
+export default tomlParse;

--- a/test/config-files/cfg/.markdownlint-cli2.toml
+++ b/test/config-files/cfg/.markdownlint-cli2.toml
@@ -1,0 +1,4 @@
+[tool.markdownlint]
+"no-trailing-spaces" = false
+"no-multiple-space-atx" = false
+"single-trailing-newline" = false

--- a/test/config-files/cfg/.markdownlint.toml
+++ b/test/config-files/cfg/.markdownlint.toml
@@ -1,0 +1,4 @@
+[tool.markdownlint]
+"no-trailing-spaces" = false
+"no-multiple-space-atx" = false
+"single-trailing-newline" = false

--- a/test/config-files/cfg/alternate.markdownlint-cli2.toml
+++ b/test/config-files/cfg/alternate.markdownlint-cli2.toml
@@ -1,0 +1,4 @@
+[markdownlint]
+"no-trailing-spaces" = false
+"no-multiple-space-atx" = false
+"single-trailing-newline" = false

--- a/test/config-files/cfg/alternate.markdownlint.toml
+++ b/test/config-files/cfg/alternate.markdownlint.toml
@@ -1,0 +1,4 @@
+[markdownlint]
+"no-trailing-spaces" = false
+"no-multiple-space-atx" = false
+"single-trailing-newline" = false

--- a/test/config-files/cfg/invalid.markdownlint-cli2.toml
+++ b/test/config-files/cfg/invalid.markdownlint-cli2.toml
@@ -1,0 +1,2 @@
+[markdownlint
+"no-trailing-spaces" = false

--- a/test/config-files/cfg/invalid.markdownlint.toml
+++ b/test/config-files/cfg/invalid.markdownlint.toml
@@ -1,0 +1,2 @@
+markdownlint]
+"no-trailing-spaces" = false

--- a/test/markdownlint-cli2-test-cases.mjs
+++ b/test/markdownlint-cli2-test-cases.mjs
@@ -701,12 +701,14 @@ const testCases = (/** @type {TestConfiguration} */ {
     ".markdownlint-cli2.yaml",
     ".markdownlint-cli2.cjs",
     ".markdownlint-cli2.mjs",
+    ".markdownlint-cli2.toml",
     ".markdownlint.jsonc",
     ".markdownlint.json",
     ".markdownlint.yaml",
     ".markdownlint.yml",
     ".markdownlint.cjs",
-    ".markdownlint.mjs"
+    ".markdownlint.mjs",
+    ".markdownlint.toml"
   ];
   for (const configFile of configFiles) {
     const usesRequire = isModule(configFile);
@@ -738,15 +740,18 @@ const testCases = (/** @type {TestConfiguration} */ {
   }
 
   const unableToParseJsonc = "Unable to parse JSONC content";
+  const unableToParseToml = "Unable to parse|Expected|Unexpected";
   const unableToRequireOrImport = "Unable to import module";
   const invalidConfigFiles = [
     [ "invalid.markdownlint-cli2.jsonc", unableToParseJsonc ],
     [ "invalid.markdownlint-cli2.cjs", unableToRequireOrImport ],
     [ "invalid.markdownlint-cli2.mjs", unableToRequireOrImport ],
+    [ "invalid.markdownlint-cli2.toml", unableToParseToml ],
     [ "invalid.markdownlint.json", unableToParseJsonc ],
     [ "invalid.markdownlint.yaml", unableToParseJsonc ],
     [ "invalid.markdownlint.cjs", unableToRequireOrImport ],
-    [ "invalid.markdownlint.mjs", unableToRequireOrImport ]
+    [ "invalid.markdownlint.mjs", unableToRequireOrImport ],
+    [ "invalid.markdownlint.toml", unableToParseToml ]
   ];
   for (const [ invalidConfigFile, stderrRe ] of invalidConfigFiles) {
     const usesRequire = isModule(invalidConfigFile);


### PR DESCRIPTION
**My motivation:**
The VS Code extension can't use a .toml file as the single source of truth for markdownlint; you still need to maintain a .markdownlint.json

**Expected usage:**
<img width="543" height="191" alt="Image" src="https://github.com/user-attachments/assets/a03a4e1b-01de-440c-8587-997520b2d4a4" />

**Issues with TOML:**
1) TOML doesn’t support null. Do you have nullable args now? extends is technically nullable, but that’s not an issue since it won’t be null by definition. Anyway, it’s worth considering as part of the ADR.
2) For now I implemented [\<any\>markdownlint]. It would be nicer to allow an explicit option like in markdownlint-cli  e.g. --configPointer "/tool/markdownlint" but it would require a larger change?


fixes:https://github.com/DavidAnson/markdownlint-cli2/issues/775