### PR TITLE
Bump markdown-it from 14.1.1 to 14.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "jsonpointer": "5.0.1",
     "markdownlint": "0.40.0",
     "markdownlint-cli2-formatter-default": "0.0.6",
-    "markdown-it": "14.1.1",
+    "markdown-it": "14.2.0",
     "micromatch": "4.0.8",
     "smol-toml": "1.6.1"
   },


### PR DESCRIPTION
Fix GHSA-6v5v-wf23-fmfq.
Pull in the smartquotes DoS fix from markdown-it 14.2.0.

---

My project had a dependabot alert about this.
For details see [GHSA-6v5v-wf23-fmfq](https://github.com/markdown-it/markdown-it/security/advisories/GHSA-6v5v-wf23-fmfq).
It is fixed in markdown-it 14.2.0 but projects using markdownlint-cli2 <=0.22.1 will still get the alert.