### PR TITLE
Update `js-yaml` package from v4 to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   ],
   "dependencies": {
     "globby": "16.2.0",
-    "js-yaml": "4.1.1",
+    "js-yaml": "5.2.0",
     "jsonc-parser": "3.3.1",
     "jsonpointer": "5.0.1",
     "markdownlint": "0.40.0",

--- a/parsers/yaml-parse.mjs
+++ b/parsers/yaml-parse.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 
-import yaml from "js-yaml";
+import { load } from 'js-yaml'
 
 /* eslint-disable arrow-body-style */
 
@@ -10,7 +10,7 @@ import yaml from "js-yaml";
  */
 const yamlParse = (text) => {
   // @ts-ignore
-  return yaml.load(text);
+  return load(text);
 };
 
 export default yamlParse;


### PR DESCRIPTION
js-yaml v4 has moderate severity vulnerabilities and should be updated to v5. This PR keeps it simple by updating the js-yaml package version and changing the now-non-existent yaml `default` export to the `load` export.